### PR TITLE
Add missing apt update to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ install on Debian. If you're looking for the yazi source code, see
 ```sh
 curl -sS https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
 echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
+sudo apt update
 sudo apt install -y yazi
 ```
 


### PR DESCRIPTION
The yazi package can't be installed after updating sources, until apt is updated. The README suggestion is incomplete.